### PR TITLE
fix(Husky): se arreglo git hooks para realizar el dotnet format y el dotnet build por separado

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-echo "Ejecutando dotnet format..."
-dotnet format
+echo "Ejecutando dotnet build..."
+dotnet build
 RESULT=$?
 
 if [ $RESULT -ne 0 ]; then
-  echo "❌ Error: dotnet format falló."
+  echo "❌ Error: dotnet build falló."
   exit 1
 fi


### PR DESCRIPTION
## 📌 Descripción

Se corrigió la configuración de los Git Hooks utilizando Husky.Net para separar las tareas de validación automática en dos hooks distintos:

- `pre-commit`: ejecuta `dotnet format` para validar el formato del código.
- `pre-push`: ejecuta `dotnet build` para asegurar que la compilación sea exitosa antes de hacer push.

---

## ✅ Cambios realizados

- Eliminación del uso incorrecto de ambos comandos en un solo hook.
- Inicialización correcta de Husky.Net con dotnet husky install.
- Creación de los archivos .husky/pre-commit y .husky/pre-push con responsabilidades separadas.
- Añadido control de errores (exit 1) en ambos scripts para prevenir commits o pushes si falla alguna validación.

---

## 🧪 Cómo probarlo

1. Ejecutar git commit con cambios mal formateados → debe fallar.
2. Ejecutar git push con errores de compilación → debe fallar.
3. Corregir los errores y repetir los pasos → debe funcionar.

---

## 🚦 Checklist

- [x] Separación correcta de dotnet format y dotnet build
- [x] Validación automática funcionando localmente
- [x] Scripts verificados en entorno de desarrollo